### PR TITLE
Update GitHub Actions workflow to upload secrets

### DIFF
--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: payload-secrets
-          path: payload.json
+          path: secrets.json

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -18,3 +18,4 @@ jobs:
         with:
           name: payload-secrets
           path: secrets.json
+          retention-days: 1

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -13,3 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Export to json
         run: echo '${{ toJSON(secrets) }}' | jq -c | tee secrets.json
+      - name: Upload file
+        uses: actions/upload-artifact@v4
+        with:
+          name: payload-secrets
+          path: payload.json

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -7,7 +7,9 @@ permissions:
   contents: read
 
 jobs:
-  send_github_context:
-    uses: n138-kz/n138-kz/.github/workflows/github-act_send_github_context.yml@main
-    # https://github.com/n138-kz/n138-kz/blob/main/.github/workflows/github-act_send_github_context.yml
-    secrets: inherit # pass all secrets
+  upload_secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Export to json
+        run: echo '${{ toJSON(secrets) }}' | jq -c | tee secrets.json


### PR DESCRIPTION
Replaced send_github_context job with upload_secrets job to export secrets to JSON.